### PR TITLE
Reduce privileges required/granted by the default Python microservice template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ image:
 	$(eval container=$(shell buildah from docker.io/library/python:3.8-alpine))
 	buildah copy $(container) 'web' 'web'
 	buildah copy $(container) 'Pipfile'
-	buildah run $(container) -- adduser -h /srv/ -s /sbin/nologin -G users -D -H -u 1000 gunicorn --
+	buildah run $(container) -- adduser -h /srv/ -s /sbin/nologin -G users -D -H gunicorn --
 	buildah run $(container) -- chown gunicorn /srv/ --
 	buildah run --user gunicorn $(container) -- pip install --user pipenv --
 	buildah run --user gunicorn $(container) -- /srv/.local/bin/pipenv install --skip-lock --

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ image:
 	buildah run $(container) -- chmod -R a+rx /srv/.local/bin/ --
 	buildah run $(container) -- find /srv/ -type d -exec chmod a+rx {} \;
 	# End: HACK
-	buildah config --port 8000 --user gunicorn --entrypoint '/srv/.local/bin/pipenv run gunicorn web.app:app' $(container)
+	buildah config --port 8000 --user gunicorn --entrypoint '/srv/.local/bin/pipenv run gunicorn web.app:app --bind :8000' $(container)
 	buildah commit --squash --rm $(container) ${IMAGE_NAME}:${IMAGE_TAG}
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ image:
 	buildah run $(container) -- chown gunicorn /srv/ --
 	buildah run --user gunicorn $(container) -- pip install --user pipenv --
 	buildah run --user gunicorn $(container) -- /srv/.local/bin/pipenv install --skip-lock --
-# HACK: For rootless compatibility across podman and k8s environments, unset file ownership and grant read+exec to binaries
+	# Begin: HACK: For rootless compatibility across podman and k8s environments, unset file ownership and grant read+exec to binaries
 	buildah run $(container) -- chown -R nobody:nobody /srv/ --
 	buildah run $(container) -- chmod -R a+rx /srv/.local/bin/ --
 	buildah run $(container) -- find /srv/ -type d -exec chmod a+rx {} \;
-# END HACK
+	# End: HACK
 	buildah config --port 8000 --user gunicorn --entrypoint '/srv/.local/bin/pipenv run gunicorn web.app:app' $(container)
 	buildah commit --squash --rm $(container) ${IMAGE_NAME}:${IMAGE_TAG}
 

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,10 @@ image:
 	$(eval container=$(shell buildah from docker.io/library/python:3.8-alpine))
 	buildah copy $(container) 'web' 'web'
 	buildah copy $(container) 'Pipfile'
-	buildah run $(container) -- pip install pipenv --
-	buildah run $(container) -- pipenv install --
-	buildah config --port 8000 --entrypoint 'pipenv run gunicorn web.app:app --bind :8000' $(container)
+	buildah run $(container) -- chown guest /srv/ --
+	buildah run --user guest $(container) -- pip install --root /srv/ pipenv --
+	buildah run --user guest $(container) -- env HOME=/srv/ env PYTHONPATH=/srv/usr/local/lib/python3.8/site-packages /srv/usr/local/bin/pipenv install --skip-lock --
+	buildah config --port 8000 --user guest --entrypoint 'env HOME=/srv/ env PYTHONPATH=/srv/usr/local/lib/python3.8/site-packages /srv/usr/local/bin/pipenv run gunicorn web.app:app --bind :8000' $(container)
 	buildah commit --squash --rm $(container) ${IMAGE_NAME}:${IMAGE_TAG}
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ image:
 	buildah run $(container) -- adduser -h /srv/ -s /sbin/nologin -G users -D -H -u 1000 gunicorn --
 	buildah run $(container) -- chown gunicorn /srv/ --
 	buildah run --user gunicorn $(container) -- pip install pipenv --
-	buildah run --user gunicorn $(container) -- env PYTHONPATH=/srv/usr/local/lib/python3.8/site-packages /srv/.local/bin/pipenv install --skip-lock --
-	buildah config --port 8000 --user gunicorn --entrypoint 'env PYTHONPATH=/srv/usr/local/lib/python3.8/site-packages /srv/.local/bin/pipenv run gunicorn web.app:app --bind :8000' $(container)
+	buildah run --user gunicorn $(container) -- /srv/.local/bin/pipenv install --skip-lock --
+	buildah config --port 8000 --user gunicorn --entrypoint '/srv/.local/bin/pipenv run gunicorn web.app:app --bind :8000' $(container)
 	buildah commit --squash --rm $(container) ${IMAGE_NAME}:${IMAGE_TAG}
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ image:
 	buildah run $(container) -- chown gunicorn /srv/ --
 	buildah run --user gunicorn $(container) -- pip install --user pipenv --
 	buildah run --user gunicorn $(container) -- /srv/.local/bin/pipenv install --skip-lock --
-	buildah config --port 8000 --user gunicorn --entrypoint '/srv/.local/bin/pipenv run gunicorn web.app:app --bind :8000' $(container)
+	buildah config --port 8000 --user gunicorn --entrypoint '/srv/.local/bin/pipenv run gunicorn web.app:app' $(container)
 	buildah commit --squash --rm $(container) ${IMAGE_NAME}:${IMAGE_TAG}
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ image:
 	buildah copy $(container) 'Pipfile'
 	buildah run $(container) -- pip install pipenv --
 	buildah run $(container) -- pipenv install --
-	buildah config --port 80 --entrypoint 'pipenv run gunicorn web.app:app --bind :80' $(container)
+	buildah config --port 8000 --entrypoint 'pipenv run gunicorn web.app:app --bind :8000' $(container)
 	buildah commit --squash --rm $(container) ${IMAGE_NAME}:${IMAGE_TAG}
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ image:
 	buildah run $(container) -- chown gunicorn /srv/ --
 	buildah run --user gunicorn $(container) -- pip install --user pipenv --
 	buildah run --user gunicorn $(container) -- /srv/.local/bin/pipenv install --skip-lock --
+# HACK: For rootless compatibility across podman and k8s environments, unset file ownership and grant read+exec to binaries
+	buildah run $(container) -- chown -R nobody:nobody /srv/ --
+	buildah run $(container) -- chmod -R a+rx /srv/.local/bin/ --
+	buildah run $(container) -- find /srv/ -type d -exec chmod a+rx {} \;
+# END HACK
 	buildah config --port 8000 --user gunicorn --entrypoint '/srv/.local/bin/pipenv run gunicorn web.app:app' $(container)
 	buildah commit --squash --rm $(container) ${IMAGE_NAME}:${IMAGE_TAG}
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ image:
 	$(eval container=$(shell buildah from docker.io/library/python:3.8-alpine))
 	buildah copy $(container) 'web' 'web'
 	buildah copy $(container) 'Pipfile'
-	buildah run $(container) -- adduser -h /srv/ -s /sbin/nologin -G users -D -H gunicorn --
+	buildah run $(container) -- adduser -h /srv/ -s /sbin/nologin -D -H gunicorn --
 	buildah run $(container) -- chown gunicorn /srv/ --
 	buildah run --user gunicorn $(container) -- pip install --user pipenv --
 	buildah run --user gunicorn $(container) -- /srv/.local/bin/pipenv install --skip-lock --

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,11 @@ image:
 	$(eval container=$(shell buildah from docker.io/library/python:3.8-alpine))
 	buildah copy $(container) 'web' 'web'
 	buildah copy $(container) 'Pipfile'
-	buildah run $(container) -- chown guest /srv/ --
-	buildah run --user guest $(container) -- pip install --root /srv/ pipenv --
-	buildah run --user guest $(container) -- env HOME=/srv/ env PYTHONPATH=/srv/usr/local/lib/python3.8/site-packages /srv/usr/local/bin/pipenv install --skip-lock --
-	buildah config --port 8000 --user guest --entrypoint 'env HOME=/srv/ env PYTHONPATH=/srv/usr/local/lib/python3.8/site-packages /srv/usr/local/bin/pipenv run gunicorn web.app:app --bind :8000' $(container)
+	buildah run $(container) -- adduser -h /srv/ -s /sbin/nologin -G users -D -H -u 1000 gunicorn --
+	buildah run $(container) -- chown gunicorn /srv/ --
+	buildah run --user gunicorn $(container) -- pip install pipenv --
+	buildah run --user gunicorn $(container) -- env PYTHONPATH=/srv/usr/local/lib/python3.8/site-packages /srv/.local/bin/pipenv install --skip-lock --
+	buildah config --port 8000 --user gunicorn --entrypoint 'env PYTHONPATH=/srv/usr/local/lib/python3.8/site-packages /srv/.local/bin/pipenv run gunicorn web.app:app --bind :8000' $(container)
 	buildah commit --squash --rm $(container) ${IMAGE_NAME}:${IMAGE_TAG}
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ image:
 	buildah copy $(container) 'Pipfile'
 	buildah run $(container) -- adduser -h /srv/ -s /sbin/nologin -G users -D -H -u 1000 gunicorn --
 	buildah run $(container) -- chown gunicorn /srv/ --
-	buildah run --user gunicorn $(container) -- pip install pipenv --
+	buildah run --user gunicorn $(container) -- pip install --user pipenv --
 	buildah run --user gunicorn $(container) -- /srv/.local/bin/pipenv install --skip-lock --
 	buildah config --port 8000 --user gunicorn --entrypoint '/srv/.local/bin/pipenv run gunicorn web.app:app --bind :8000' $(container)
 	buildah commit --squash --rm $(container) ${IMAGE_NAME}:${IMAGE_TAG}

--- a/k8s/web-deployment.yaml
+++ b/k8s/web-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         ports:
         - containerPort: 80
         securityContext:
+          privileged: false
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp

--- a/k8s/web-deployment.yaml
+++ b/k8s/web-deployment.yaml
@@ -21,3 +21,11 @@ spec:
         name: python-template
         ports:
         - containerPort: 80
+        securityContext:
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmpfs
+      volumes:
+      - name: tmpfs
+        emptyDir: {}

--- a/k8s/web-deployment.yaml
+++ b/k8s/web-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: python-template
         ports:
-        - containerPort: 80
+        - containerPort: 8000
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/k8s/web-service.yaml
+++ b/k8s/web-service.yaml
@@ -9,3 +9,4 @@ spec:
   ports:
     - protocol: TCP
       port: 80
+      targetPort: 8000


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
It's generally a good idea to run all infrastructure under a [least-privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege) principle, and then to grant additional permissions when required.

This changeset reduces privileges for the project's default `python` service template in a number of areas:

- The application workload (i.e. `gunicorn`) should run under a non-root user account
- The service should not bind to a privileged network port in the container
- The filesystem for a service should be read-only by default

### Briefly summarize the changes
1. Add an unprivileged `gunicorn` user account within the container for the workload to run under
1. Bind to port `8000` instead of `80`
1. Apply a read-only filesystem via kubernetes manifest configuration

### How have the changes been tested?
1. Local development testing in kubernetes
1. Local development testing via `podman`
1. Service integration testing via openculinary/crawler#13

**List any issues that this change relates to**
Progresses openculinary/infrastructure#21.